### PR TITLE
Feature/aws sqs utility allow fifo messages

### DIFF
--- a/src/sqsClientUtils.js
+++ b/src/sqsClientUtils.js
@@ -22,7 +22,7 @@ function reduceMessageAttributes(attributes) {
 }
 
 function toCsvMessage(sqsMessage) {
-    return {
+    const csvMessage = {
         MessageId: sqsMessage.MessageId,
         SenderId: sqsMessage.Attributes.SenderId,
         Sent: toDateString(sqsMessage.Attributes.SentTimestamp),
@@ -32,14 +32,30 @@ function toCsvMessage(sqsMessage) {
         MessageAttributes: reduceMessageAttributes(sqsMessage.MessageAttributes),
         ReceiptHandle: sqsMessage.ReceiptHandle,
     };
+
+    // FIFO
+    if (sqsMessage.Attributes.MessageGroupId != null) {
+        csvMessage.MessageGroupId = sqsMessage.Attributes.MessageGroupId;
+        csvMessage.MessageDeduplicationId = sqsMessage.Attributes.MessageDeduplicationId;
+    }
+
+    return csvMessage;
 }
 
 function toSqsSend(csvMessage) {
-    return {
+    const sqsMessage = {
         Id: csvMessage.MessageId,
         MessageBody: csvMessage.Body,
         MessageAttributes: csvMessage.MessageAttributes,
     };
+
+    // FIFO
+    if (csvMessage.MessageGroupId != null) {
+        sqsMessage.MessageGroupId = csvMessage.MessageGroupId;
+        sqsMessage.MessageDeduplicationId = csvMessage.MessageDeduplicationId;
+    }
+
+    return sqsMessage;
 }
 
 function toSqsDelete(csvMessage) {


### PR DESCRIPTION
This allows --list and  --load commands to read from and write to FIFO type SQS queues. Currently only works for Standard queues as MessageGroupId isn't stored or sent.

The --list command will now include MessageGroupId and MessageDeduplicationId columns in the generated CSV for FIFO queues. If MessageGroupId is not present then it is a Standard queue, and neither new column will be included in the CSV.

The --load command will now include MessageGroupId and MessageDeduplicationId in messages sent to the queue if present. MessageGroupId is required when adding to a FIFO queue. MessageDeduplicationId is optional and can be undefined.